### PR TITLE
add function for easy access to raw sql from current query criteria

### DIFF
--- a/runtime/lib/query/Criteria.php
+++ b/runtime/lib/query/Criteria.php
@@ -1444,6 +1444,19 @@ class Criteria implements IteratorAggregate
     }
 
     /**
+     * Returns the current query as SQL statement (request is executed on database)
+     *
+     * @return string
+     */
+    public function toRawSql()
+    {
+        return (clone $this)
+            ->setFormatter('PropelStatementFormatter')
+            ->find()
+            ->queryString;
+    }
+
+    /**
      * Returns the size (count) of this criteria.
      * @return int
      */


### PR DESCRIPTION
this improves debugging when building a criteria query by providing quick and easy access to the generated SQL without the need to wrap the criteria query in 
```
\Propel::getConnection()->useDebug(true);

/** build and execute query 

/** @var string $almostSqlString - get propel query without variables used in execution */
$almostSqlString = \Propel::getConnection()->getLastExecutedQuery();
```

debugging when building a criteria query can now be done by
```
<?
$sampleQuery = SampleQuery::create()
    ->filterByIsActive(true)
    ->filterByName("john%", \Criteria::LIKE)
    ->filterByName("%doe", \Criteria::LIKE)
    ->filterByEmail([
        "john@example.com",
        "jdoe@example.com",
        "john.doe@example.com",
    ], \Criteria::IN)
    ->limit(10);

/** 
 * get current query as being built with no impact
 * on the current state of $sampleQuery
 * ~ will execute sql on server ~
 * @var string $sampleSql
 */
$sampleSql = $sampleQuery->toRawSql();

/** still able to process criteria query and receive response from server as expected */
/** @var PropelCollection $sampleData */
$sampleData = $sampleQuery->find();
```

using ` ->toRawSql() ` on the criteria query will have no impact on the current criteria query due to using a [clone of the current criteria query](https://github.com/PlaygroundSessions/Propel/pull/1/files#diff-3cdcb936e161ee64c7da4444a912ca58R1453) allowing continue working with the current criteria and being able to receive results after returning the current SQL with all used variables in place.
